### PR TITLE
Fix distance calculation in Vector2f

### DIFF
--- a/GatcherTheEggs/src/framework/Vector2f.java
+++ b/GatcherTheEggs/src/framework/Vector2f.java
@@ -17,12 +17,12 @@ public class Vector2f {
 		this.y = y;
 	}
 	
-	public float getDistance(Vector2f vecTo) {
-		double xDist = vecTo.x - x;
-		double yDist = vecTo.y = y;
-		
-		return (float) Math.sqrt(Math.pow(xDist, xDist) + Math.pow(yDist, yDist));
-	}
+        public float getDistance(Vector2f vecTo) {
+                double xDist = vecTo.x - x;
+                double yDist = vecTo.y - y;
+
+                return (float) Math.sqrt(Math.pow(xDist, 2) + Math.pow(yDist, 2));
+        }
 	
 	public Vector2f cpy() {
 		return new Vector2f(x, y);


### PR DESCRIPTION
## Summary
- correct subtraction in `Vector2f.getDistance`
- use squared distance instead of exponentiating by the value itself

## Testing
- `javac $(find GatcherTheEggs/src -name '*.java') -d /tmp/gtetarget` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_683f4adea0508328a950cb8e71c80fb2